### PR TITLE
検索機能をパワーアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,4 @@
 @import "diagnosis-new";
 @import "show";
 @import "dog_index";
+@import "board_index";

--- a/app/assets/stylesheets/board_index.scss
+++ b/app/assets/stylesheets/board_index.scss
@@ -1,0 +1,3 @@
+.text-decoration-none {
+  text-decoration: none;
+}

--- a/app/controllers/dogs/lists_controller.rb
+++ b/app/controllers/dogs/lists_controller.rb
@@ -1,6 +1,12 @@
 class Dogs::ListsController < ApplicationController
   def index
-    @list_dogs = Dog.where('breed LIKE ? AND display_in_index = ?', "%#{params[:breed]}%", 1)
+    limited_breeds = params[:limited_breeds]
+    
+    if limited_breeds == 'limited_display'
+      @list_dogs = Dog.where('breed LIKE ? AND display_in_index = ?', "%#{params[:breed]}%", 1)
+    else
+      @list_dogs = Dog.where('breed LIKE ?', "%#{params[:breed]}%")
+    end
     respond_to do |format|
       format.html { redirect_to :root }
       format.json { render json: @list_dogs }

--- a/app/javascript/dog/index.js
+++ b/app/javascript/dog/index.js
@@ -1,5 +1,6 @@
 $(document).on('turbo:load', function () {
   $(function () {
+    var limitedBreeds = $('.js-text_field').data('limitedBreeds'); // 犬種検索に制限をかけたいページの変数を取得
     $('.js-text_field').on('keyup', function () {
       var user_input = $.trim($(this).val());
 
@@ -13,7 +14,7 @@ $(document).on('turbo:load', function () {
       $.ajax({
         type: 'GET', // リクエストのタイプ
         url: '/dogs/lists', // リクエストを送信するURL
-        data:  { breed: user_input }, // サーバーに送信するデータ
+        data:  { breed: user_input, limited_breeds: limitedBreeds }, // サーバーに送信するデータ
         dataType: 'json' // サーバーから返却される型
       })
       .done(function (data) {

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -5,6 +5,17 @@ class Board < ApplicationRecord
 
   # 他テーブルとの関係性
   belongs_to :user
+  belongs_to :dog, optional: true
   has_many :bookmarks, dependent: :destroy
   has_many :comments, dependent: :destroy
+
+  # ransackを使用するための設定
+  def self.ransackable_attributes(auth_object = nil)
+    ["body", "created_at", "dog_id", "id", "id_value", "title", "updated_at", "user_id"]
+  end
+  
+  def self.ransackable_associations(auth_object = nil)
+    ["bookmarks", "comments", "dog", "user"]
+  end
+
 end

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -3,6 +3,7 @@ class Dog < ApplicationRecord
   belongs_to :dog_size_type
   belongs_to :dog_country
   has_many :dog_answer_relationships, dependent: :destroy
+  has_many :boards, dependent: :destroy
 
   # バリデーションの設定
   validates :breed, presence: true

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -26,6 +26,24 @@
             <% end %>
           <% end %>
         </div>
+
+        <div class="mt-2">
+          <% if board.dog_id.present? %> <%# 投稿時に犬種情報を入力しているか %>
+            <h5 class="d-flex align-items-center mb-0">
+              <% if board.dog.display_in_index == 1 %>
+                <%= link_to dog_path(board.dog), class: "text-decoration-none" do %>
+                  <i class="fa-solid fa-dog"></i>
+                  <%= board.dog.breed %>
+                <% end %>
+              <% else %>
+                <div class='text-decoration-none text-primary-emphasis'>
+                  <i class="fa-solid fa-dog"></i>
+                  <%= board.dog.breed %>
+                </div>
+              <% end %>
+            </h5>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -1,26 +1,31 @@
+<%# JSの読み込み %>
+<% content_for :js do %>
+  <%= javascript_import_module_tag "dog/index" %>
+<% end %>
+
 <%= form_with model: board, data: { turbo_method: :post } do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
-    <div class="form-group">
+    <div class="form-group mb-2">
       <%= f.label :title %>
-      <%= f.text_field :title, class: 'form-control' %>
+      <%= f.text_field :title, class: 'form-control', placeholder: t('boards.new.input_title') %>
     </div>
-    <div class="form-group">
+    <div class="form-group mb-2">
       <%= f.label :body %>
-      <%= f.text_area :body, class: 'form-control', rows: 10 %>
+      <%= f.text_area :body, class: 'form-control', rows: 10, placeholder: t('boards.new.input_body') %>
+    </div>
+    <div class="form-group mb-2">
+      <%= f.label :dog_id %>
+      <%= f.collection_select :dog_id, @dogs, :id, :breed, { prompt: t('boards.new.choose_breed') }, class: 'form-control' %>
     </div>
 <%
 =begin 
 %>
-   <div class="form-group">
-     <%= f.label :dog_id, t('boards.new.what_breed') %>
-     <%= f.collection_select :dog_id, @dogs, :id, :breed, { prompt: t('boards.new.what_breed_prompt') }, class: 'form-control' %>
-   </div>
   <div class="form-group">
     <%= f.label :board_image %>
-    <%= f.file_field :board_image, id: 'board_board_image', class: 'form-control mb-3', accept: 'image/*' %>
+    <%= f.file_field :board_image, id: 'board_board_image', class: 'form-control mb-2', accept: 'image/*' %>
     <%= f.hidden_field :board_image_cache %>
   </div>
-  <div class="mt-3 mb-3">
+  <div class="mt-3 mb-2">
 	  <%# 以下はプレビュー画面を表示するコード %>
     <%= image_tag board.board_image.url, id: 'preview', size: '200x200' %>
     <%= javascript_include_tag 'board_form' %>

--- a/app/views/boards/bookmarks.html.erb
+++ b/app/views/boards/bookmarks.html.erb
@@ -2,38 +2,34 @@
 <% content_for(:title, t('.title')) %>
 <%# パンクズリストの読み込み %>
 <% breadcrumb :bookmark_board_index %>
+<%# JSの読み込み %>
+<% content_for :js do %>
+  <%= javascript_import_module_tag "dog/index" %>
+<% end %>
 
 <div class="container pt-3">
-  <div class="row">
-    <div class="col-lg-10 offset-lg-1 col-md-12">
-
-      <!-- 投稿作成誘導ボタン -->
-      <% if logged_in? %>
-        <div class="d-grid gap-2 mb-2">
-          <%= link_to t('boards.index.post'), new_board_path, class: "btn btn-outline-primary", role: "button", data: { turbo_stream: true } %>
-        </div>
-      <% else %>
-        <div class="d-grid gap-2 mb-2">
-          <%= link_to t('boards.index.before_login_post'), new_board_path, class: "btn btn-outline-primary", role: "button" %>
-        </div>
-      <% end %>
-
-<%
-=begin 
-%>
-
-      <%# 検索フォーム %>
-      <%= content_tag(:div, class: 'mb-1') do %>
-        <%= content_tag(:i, nil, class: 'fas fa-search', style: 'margin-right: 5px;') %> 投稿検索
-      <% end %>
-      <%= render 'search_form', url: boards_path %>
+  <!-- 投稿作成誘導ボタン -->
+  <% if logged_in? %>
+    <div class="d-grid gap-2 mb-2">
+      <%= link_to t('boards.index.post'), new_board_path, class: "btn btn-outline-primary", role: "button", data: { turbo_stream: true } %>
     </div>
-  </div>
-
-<%
-=end 
-%>
-
+  <% else %>
+    <div class="d-grid gap-2 mb-2">
+      <%= link_to t('boards.index.before_login_post'), new_board_path, class: "btn btn-outline-primary", role: "button" %>
+    </div>
+  <% end %>
+  <%# 検索フォーム %>
+  <%= search_form_for @q, url: bookmarks_boards_path do |f| %>
+    <div class="input-group mb-3">
+      <%= f.search_field :dog_breed_cont, class: 'js-text_field', placeholder: t('.dog_search_word'), size: 50, autocomplete: 'off' %>
+      <%= f.search_field :title_or_body_cont, class: "form-control", placeholder: t('.title_or_body_search_word') %>
+      <div class="input-group-append">
+        <%= f.submit class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+  <ul class="js-lists">
+  </ul>
   <!-- 掲示板一覧 -->
   <div class="row">
     <div class="col-12">

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -2,38 +2,34 @@
 <% content_for(:title, t('.title')) %>
 <%# パンクズリストの読み込み %>
 <% breadcrumb :board_index %>
+<%# JSの読み込み %>
+<% content_for :js do %>
+  <%= javascript_import_module_tag "dog/index" %>
+<% end %>
 
 <div class="container pt-3">
-  <div class="row">
-    <div class="col-lg-10 offset-lg-1 col-md-12">
-
-      <!-- 投稿作成誘導ボタン -->
-      <% if logged_in? %>
-        <div class="d-grid gap-2 mb-2">
-          <%= link_to t('boards.index.post'), new_board_path, class: "btn btn-outline-primary", role: "button", data: { turbo_stream: true } %>
-        </div>
-      <% else %>
-        <div class="d-grid gap-2 mb-2">
-          <%= link_to t('boards.index.before_login_post'), new_board_path, class: "btn btn-outline-primary", role: "button" %>
-        </div>
-      <% end %>
-
-<%
-=begin 
-%>
-
-      <%# 検索フォーム %>
-      <%= content_tag(:div, class: 'mb-1') do %>
-        <%= content_tag(:i, nil, class: 'fas fa-search', style: 'margin-right: 5px;') %> 投稿検索
-      <% end %>
-      <%= render 'search_form', url: boards_path %>
+  <!-- 投稿作成誘導ボタン -->
+  <% if logged_in? %>
+    <div class="d-grid gap-2 mb-2">
+      <%= link_to t('boards.index.post'), new_board_path, class: "btn btn-outline-primary", role: "button", data: { turbo_stream: true } %>
     </div>
-  </div>
-
-<%
-=end 
-%>
-
+  <% else %>
+    <div class="d-grid gap-2 mb-2">
+      <%= link_to t('boards.index.before_login_post'), new_board_path, class: "btn btn-outline-primary", role: "button" %>
+    </div>
+  <% end %>
+  <%# 検索フォーム %>
+  <%= search_form_for @q, url: boards_path do |f| %>
+    <div class="input-group mb-3">
+      <%= f.search_field :dog_breed_cont, class: 'js-text_field', placeholder: t('.dog_search_word'), size: 50, autocomplete: 'off' %>
+      <%= f.search_field :title_or_body_cont, class: "form-control", placeholder: t('.title_or_body_search_word') %>
+      <div class="input-group-append">
+        <%= f.submit class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+  <ul class="js-lists">
+  </ul>
   <!-- 掲示板一覧 -->
   <div class="row">
     <div class="col-12">
@@ -41,7 +37,7 @@
         <% if @boards.present? %>
           <%= render @boards %>
         <% else %>
-          <p><%= t('boards.bookmarks.no_result') %></p>
+          <p><%= t('.no_board') %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/dogs/index.html.erb
+++ b/app/views/dogs/index.html.erb
@@ -12,7 +12,7 @@
   <%# 検索フォーム %>
   <%= search_form_for @q, url: dogs_path do |f| %>
     <div class="input-group mb-3">
-      <%= f.search_field :breed_cont, class: 'js-text_field', placeholder: t('.search_word'), size: 50, autocomplete: 'off' %>
+      <%= f.search_field :breed_cont, class: 'js-text_field', placeholder: t('.search_word'), size: 50, autocomplete: 'off', data: { limited_breeds: 'limited_display' }  %>
       <div class="input-group-append">
         <%= f.submit class: 'btn btn-primary' %>
       </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -11,7 +11,8 @@ ja:
         password_confirmation: 'パスワード（確認用）'
       board:
         title: 'タイトル'
-        body: '本文'  
+        body: '本文'
+        dog_id: '犬種'
         created_at: '投稿日時'
       comment:
         body: 'コメント'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -43,6 +43,10 @@ ja:
     new:
       title: '投稿作成'
       post: '投稿する'
+      what_breed: '犬種'
+      input_title: 'タイトルを入力してください（必須）'
+      input_body: '本文を入力してください（必須）'
+      choose_breed: '犬種を選択してください（任意）'
     create:
       success: '投稿しました'
       fail: '投稿できませんでした'
@@ -50,6 +54,9 @@ ja:
       title: '投稿一覧'
       post: '投稿する'
       before_login_post: 'ログインして投稿する'
+      no_board: '投稿はまだありません'
+      dog_search_word: '犬種名を入力してください'
+      title_or_body_search_word: '投稿のキーワードを入力してください'
     show:
       title: '投稿詳細'
       to_board_index: '投稿一覧へ戻る'
@@ -59,6 +66,8 @@ ja:
     bookmarks:
       title: 'お気に入り投稿'
       no_result: 'お気に入り投稿はありません'
+      dog_search_word: '犬種名を入力してください'
+      title_or_body_search_word: '投稿のキーワードを入力してください'
   comments:
     partial:
       require_comment: 'コメントを入力してください'

--- a/db/migrate/20240403151714_add_dog_ref_to_boards.rb
+++ b/db/migrate/20240403151714_add_dog_ref_to_boards.rb
@@ -1,0 +1,5 @@
+class AddDogRefToBoards < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :boards, :dog, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_30_064148) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_03_151714) do
   create_table "answers", force: :cascade do |t|
     t.text "content"
     t.text "explain"
@@ -26,6 +26,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_30_064148) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "dog_id"
+    t.index ["dog_id"], name: "index_boards_on_dog_id"
     t.index ["user_id"], name: "index_boards_on_user_id"
   end
 
@@ -118,6 +120,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_30_064148) do
   end
 
   add_foreign_key "answers", "questions"
+  add_foreign_key "boards", "dogs"
   add_foreign_key "boards", "users"
   add_foreign_key "bookmarks", "boards"
   add_foreign_key "bookmarks", "users"


### PR DESCRIPTION
既存
犬種一覧の検索機能

新規
投稿一覧の犬種検索機能
お気に入り投稿一覧の犬種検索機能
投稿にdogsテーブルと紐づくためのカラムを追加してる
投稿一覧の犬種情報から犬種詳細に飛べるようにしている
データ未入力の犬種についてはリンクをつけていない

備考
犬種一覧と投稿一覧では検索時にインクリメンタル機能で出てくる犬種の候補に違いを出している
犬種一覧→情報を入力している犬種のみ
投稿一覧→全ての犬種から検索の予測が出現する
